### PR TITLE
Fix: Pass IsHttps parameter to endpoint URL builder

### DIFF
--- a/ArshidAspireApiDocsExtensions/Extensions.cs
+++ b/ArshidAspireApiDocsExtensions/Extensions.cs
@@ -37,7 +37,7 @@ public static class Extensions
         builder.WithCommand(
             name: "OpenApi",
             displayName: "OpenApi",
-            executeCommand: context => OnLinkOpenerCommandAsync(builder, context, "/OpenApi/v1.json"),
+            executeCommand: context => OnLinkOpenerCommandAsync(builder, context, "/OpenApi/v1.json", IsHttps: IsHttps),
             commandOptions: new CommandOptions
             {
                 IconName = "Accessibility",
@@ -52,7 +52,7 @@ public static class Extensions
         builder.WithCommand(
             name: "Scalar",
             displayName: "Scalar",
-            executeCommand: context => OnLinkOpenerCommandAsync(builder, context, "/Scalar/v1"),
+            executeCommand: context => OnLinkOpenerCommandAsync(builder, context, "/Scalar/v1", IsHttps: IsHttps),
             commandOptions: new CommandOptions
             {
                 IconName = "Accessibility",
@@ -67,7 +67,7 @@ public static class Extensions
         builder.WithCommand(
             name: "Swagger",
             displayName: "Swagger",
-            executeCommand: context => OnLinkOpenerCommandAsync(builder, context, "/Swagger/index.html"),
+            executeCommand: context => OnLinkOpenerCommandAsync(builder, context, "/Swagger/index.html", IsHttps: IsHttps),
             commandOptions: new CommandOptions
             {
                 IconName = "Accessibility",


### PR DESCRIPTION
## Description
The `IsHttps` parameter was defined in `WithOpenApi`, `WithScalar`, and `WithSwagger` methods but was never passed to `OnLinkOpenerCommandAsync`. This fix ensures the parameter is correctly forwarded, allowing users to specify HTTPS endpoints.

## Changes
- Pass `IsHttps` parameter to `OnLinkOpenerCommandAsync` in:
  - `WithOpenApi()`
  - `WithScalar()`
  - `WithSwagger()`

## Usage Example
```csharp
builder.AddProject<Projects.MyApi>("api")
    .WithSwagger(IsHttps: true)  // Now works correctly!
    .WithScalar(IsHttps: true);
