### PR TITLE
Fix: Update tests to use correct resource names

### DIFF
--- a/Test/AspireAppTest.Tests/WebTests.cs
+++ b/Test/AspireAppTest.Tests/WebTests.cs
@@ -4,7 +4,7 @@ namespace AspireAppTest.Tests;
 public class WebTests
 {
     [TestMethod]
-    public async Task GetWebResourceRootReturnsOkStatusCode()
+    public async Task GetApiServiceRootReturnsOkStatusCode()
     {
         // Arrange
         var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.AspireAppTest_AppHost>();
@@ -18,8 +18,31 @@ public class WebTests
         await app.StartAsync();
 
         // Act
-        var httpClient = app.CreateHttpClient("webfrontend");
-        await resourceNotificationService.WaitForResourceAsync("webfrontend", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+        var httpClient = app.CreateHttpClient("ApiService");
+        await resourceNotificationService.WaitForResourceAsync("ApiService", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
+        var response = await httpClient.GetAsync("/weatherforecast");
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task GetBlazorAppRootReturnsOkStatusCode()
+    {
+        // Arrange
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.AspireAppTest_AppHost>();
+        appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
+        {
+            clientBuilder.AddStandardResilienceHandler();
+        });
+
+        await using var app = await appHost.BuildAsync();
+        var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.StartAsync();
+
+        // Act
+        var httpClient = app.CreateHttpClient("BlazorApp");
+        await resourceNotificationService.WaitForResourceAsync("BlazorApp", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
         var response = await httpClient.GetAsync("/");
 
         // Assert


### PR DESCRIPTION
## Description
The existing test referenced a non-existent resource `webfrontend`. Updated tests to use the actual resource names defined in `AppHost/Program.cs`.

## Changes
- Renamed test method to `GetApiServiceRootReturnsOkStatusCode`
- Changed resource name from `webfrontend` to `ApiService`
- Updated endpoint from `/` to `/weatherforecast` (valid API endpoint)
- Added new test `GetBlazorAppRootReturnsOkStatusCode` for BlazorApp resource

## Why
The original test would fail because:
1. `webfrontend` resource doesn't exist in the AppHost
2. The actual resources are `ApiService` and `BlazorApp`
