### PR TITLE
Feature: Add distinct icons for each command type

### DIFF
--- a/ArshidAspireApiDocsExtensions/Extensions.cs
+++ b/ArshidAspireApiDocsExtensions/Extensions.cs
@@ -10,7 +10,7 @@ public static class Extensions
             executeCommand: context => OnLinkOpenerCommandAsync(builder, context, CustomRoute),
             commandOptions: new CommandOptions
             {
-                IconName = "Accessibility",
+                IconName = "Link",
                 IconVariant = IconVariant.Filled
             });
         return builder;
@@ -25,7 +25,7 @@ public static class Extensions
             executeCommand: context => OnLinkOpenerCommandAsync(builder, context, CustomUrl: CustomUrl),
             commandOptions: new CommandOptions
             {
-                IconName = "Accessibility",
+                IconName = "Globe",
                 IconVariant = IconVariant.Filled
             });
         return builder;
@@ -40,7 +40,7 @@ public static class Extensions
             executeCommand: context => OnLinkOpenerCommandAsync(builder, context, "/OpenApi/v1.json"),
             commandOptions: new CommandOptions
             {
-                IconName = "Accessibility",
+                IconName = "Document",
                 IconVariant = IconVariant.Filled
             });
         return builder;
@@ -55,7 +55,7 @@ public static class Extensions
             executeCommand: context => OnLinkOpenerCommandAsync(builder, context, "/Scalar/v1"),
             commandOptions: new CommandOptions
             {
-                IconName = "Accessibility",
+                IconName = "BookOpen",
                 IconVariant = IconVariant.Filled
             });
         return builder;
@@ -70,7 +70,7 @@ public static class Extensions
             executeCommand: context => OnLinkOpenerCommandAsync(builder, context, "/Swagger/index.html"),
             commandOptions: new CommandOptions
             {
-                IconName = "Accessibility",
+                IconName = "Code",
                 IconVariant = IconVariant.Filled
             });
         return builder;


### PR DESCRIPTION
## Description
Previously, all commands used the same `Accessibility` icon, making it difficult to distinguish between different documentation types in the Aspire dashboard. This PR assigns unique, meaningful icons to each command.

## Changes
| Method | Old Icon | New Icon |
|--------|----------|----------|
| `WithRoute()` | Accessibility | Link |
| `WithCustomUrl()` | Accessibility | Globe |
| `WithOpenApi()` | Accessibility | Document |
| `WithScalar()` | Accessibility | BookOpen |
| `WithSwagger()` | Accessibility | Code |

## Benefits
- Better visual distinction between different documentation types
- More intuitive icons that represent the purpose of each link
- Improved UX in the Aspire dashboard
